### PR TITLE
✨ Port kann aus Environmentvariable gelesen werden

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::env;
 use axum::{routing::get, Router};
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
@@ -6,7 +7,11 @@ use tokio::net::TcpListener;
 async fn main() {
     let app = Router::new().route("/", get(handler));
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
+    let port: u16 = env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000);
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = TcpListener::bind(addr).await.unwrap();
 
     println!("listening on {}", addr);


### PR DESCRIPTION
- Heroku erlaubt keine freie Portvergabe

Ich werde den PR selber mergen, da ich das Deployment testen muss.